### PR TITLE
After update install assets (again)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,9 @@
     "scripts": {
         "post-create-project-cmd": [
             "Bolt\\Composer\\ScriptHandler::bootstrap"
+        ],
+        "post-update-cmd": [
+            "Bolt\\Composer\\ScriptHandler::installAssets"
         ]
     },
     "extra": {


### PR DESCRIPTION
When updating bolt with composer, assets need to be installed again because those assets may be updated in the new release.