### PR TITLE
Gitignore updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,26 +1,28 @@
-cache/
-thumbs/
-vendor/
+# PHP files and folders
+/vendor
+composer.phar
+php-cs-fixer.phar
+scrutinizer.phar
 
 # NPM, Gulp and Grunt stuff
-node_modules
-bower_components
-npm-debug.log
 .sass-cache
+bower_components
+node_modules
+npm-debug.log
 
 # File-system cruft and temporary files
-scrutinizer.phar
-php-cs-fixer.phar
+*.gz
+*.sublime-*
+*.zip
+.*.swp
+._*
+.buildpath
 .DS_Store
 .idea
-__*
-._*
-Vagrantfile
-.vagrant*
-*.sublime-*
-/tags
-.*.swp
-.swp
-.buildpath
 .project
-/bolt.log
+.swp
+.Trashes
+.vagrant*
+__*
+Thumbs.db
+Vagrantfile

--- a/app/cache/.gitignore
+++ b/app/cache/.gitignore
@@ -1,1 +1,2 @@
+*
 !.gitignore

--- a/app/database/.gitignore
+++ b/app/database/.gitignore
@@ -1,1 +1,2 @@
+*
 !.gitignore

--- a/public/bolt-public/.gitignore
+++ b/public/bolt-public/.gitignore
@@ -1,1 +1,2 @@
+*
 !.gitignore

--- a/public/files/.gitignore
+++ b/public/files/.gitignore
@@ -1,0 +1,1 @@
+!.gitignore

--- a/public/files/.gitignore
+++ b/public/files/.gitignore
@@ -1,1 +1,2 @@
+*
 !.gitignore

--- a/public/theme/.gitignore
+++ b/public/theme/.gitignore
@@ -1,2 +1,0 @@
-!.gitignore
-!.htaccess

--- a/public/thumbs/.gitignore
+++ b/public/thumbs/.gitignore
@@ -1,1 +1,2 @@
+*
 !.gitignore


### PR DESCRIPTION
Major:
- Fixed ignoring everything in `app/cache`, `app/database`, `public/thumbs`, `public/files/`, and `public/bolt-public`.
- Un-ignored `public/theme/` folder. These files should be committed.

Minor:
- Ignored `composer.phar`.
- Removed `/tags` and `/bolt.log`, both are unused.
- Removed unused `.htaccess` in `public/theme/`. I think it was used as a placeholder for git to keep the directory which `.gitignore` has been doing.
- Sorted `.gitignore` alphabetically.

TBD: Should `app/config/config.yml` be ignored by default? It can contain secrets, but doesn't have to. 
