### PR TITLE
Tweak git ignore files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # PHP files and folders
 /vendor
+
+# Common developer tools
 composer.phar
 php-cs-fixer.phar
 scrutinizer.phar

--- a/public/extensions/.gitignore
+++ b/public/extensions/.gitignore
@@ -1,1 +1,2 @@
-vendor
+*
+!.gitignore

--- a/public/theme/.gitignore
+++ b/public/theme/.gitignore
@@ -1,0 +1,1 @@
+!.gitignore


### PR DESCRIPTION
The two in `public/` just keep themselves around, and the `public/extensions/` directory should be considered volatile in the same way that `public/bolt-public/` is.

Need … more … :coffee: 

**Update:** This is linked to the results of testing https://github.com/bolt/bolt/pull/6733