### PR TITLE
Default site bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,11 @@
             "nut extensions:setup"
         ]
     },
+    "autoload": {
+        "psr-4": {
+            "Bundle\\": "src/"
+        }
+    },
     "extra": {
         "branch-alias": {
             "dev-3.4" : "3.4.x-dev"

--- a/src/Site/CustomisationExtension.php
+++ b/src/Site/CustomisationExtension.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Bundle\Site;
+
+use Bolt\Extension\SimpleExtension;
+
+/**
+ * Site bundle extension loader.
+ *
+ * This is the base bundle you can use to further customise Bolt for your
+ * specific site.
+ *
+ * It is perfectly safe to remove this bundle, just remember to remove the
+ * entry from your .bolt.yml or .bolt.php file.
+ *
+ * For more information on building bundles see https://docs.bolt.cm/extensions
+ */
+class CustomisationExtension extends SimpleExtension
+{
+}


### PR DESCRIPTION
Please treat this as RFC status until we've all had a chance to chime in.

## Problem

- Despite documentation, people are having issues creating bundles

People without much exposure to Composer & PHP generally want to add small additions to the site, when this "looks" too hard, they often make feature requests for things that don't belong in core.

## Concept

My proposed, PoC, solution here is the addition of a "site bundle" that people can use to build on, quickly!

e.g.
>> How do I add something to Twig to upper case the 'b' in Bolt when I forget

> Easy, just add a `registerTwigFilters` method to your Site Bundle. See https://docs.bolt.cm/extensions/basics/twig for details

For those of us that want to customise, and RTFM, we can just delete/rename/modify or just :koala: until our hearts are content.

## Caveat

What to do about archive distributions? 

Probably best to make `.bolt.yml` into `.bolt.yml.dist`
