### PR TITLE
Remove passwordlib/passwordlib from the required packages.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,7 @@
     "license": "MIT",
     "require": {
         "php": "^5.5.9 || ^7.0",
-        "bolt/bolt": "^3.6@dev",
-        "passwordlib/passwordlib": "^1.0@beta"
+        "bolt/bolt": "^3.6@dev"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
We don't need it _here_, since `bolt/bolt` itself already requires it.
This change should have no real-life implications, beyond "being tidy".

Fixes #29